### PR TITLE
Fix table existence check bug

### DIFF
--- a/DbUp.Snowflake.csproj
+++ b/DbUp.Snowflake.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <!-- SonarQube needs this -->
     <ProjectGuid>{66666666-FECC-FECC-FECC-666666666666}</ProjectGuid>
     <PackageId>B3zaleel.DbUp.Snowflake</PackageId>
@@ -14,8 +14,8 @@
     <Version>0.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="dbup-core" Version="4.4.0" />
-    <PackageReference Include="System.Data.Odbc" Version="4.7.0" />
+    <PackageReference Include="dbup-core" Version="5.0.37" />
+    <PackageReference Include="Snowflake.Data" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SnowflakeExtensions.cs
+++ b/SnowflakeExtensions.cs
@@ -22,7 +22,16 @@ public static class SnowflakeExtensions
     /// A builder for a database upgrader designed for Snowflake databases.
     /// </returns>
     public static UpgradeEngineBuilder SnowflakeDatabase(this SupportedDatabases supported, string connectionString)
-        => SnowflakeDatabase(supported, connectionString, null);
+    {
+        var connectionStringFields = connectionString.Split(';');
+        var schema = connectionStringFields
+            .FirstOrDefault(x => x.StartsWith("schema", StringComparison.InvariantCultureIgnoreCase))
+            ?.Split('=').Last();
+        var database = connectionStringFields
+            .First(x => x.StartsWith("database", StringComparison.InvariantCultureIgnoreCase) || x.StartsWith("db", StringComparison.InvariantCultureIgnoreCase))
+            .Split('=').Last();
+        return SnowflakeDatabase(new SnowflakeConnectionManager(connectionString), schema, database);
+    }
 
     /// <summary>
     /// Creates an upgrade engine builder for Snowflake databases.
@@ -35,7 +44,9 @@ public static class SnowflakeExtensions
     /// </returns>
     public static UpgradeEngineBuilder SnowflakeDatabase(this SupportedDatabases supported, string connectionString, string schema)
     {
-        var database = connectionString.Split(';').First(x => x.StartsWith("database", StringComparison.InvariantCultureIgnoreCase)).Split('=').Last();
+        var database = connectionString.Split(';')
+            .First(x => x.StartsWith("database", StringComparison.InvariantCultureIgnoreCase) || x.StartsWith("db", StringComparison.InvariantCultureIgnoreCase))
+            .Split('=').Last();
         return SnowflakeDatabase(new SnowflakeConnectionManager(connectionString), schema, database);
     }
 

--- a/SnowflakeScriptExecutor.cs
+++ b/SnowflakeScriptExecutor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.Odbc;
+using Snowflake.Data.Client;
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
@@ -26,9 +26,9 @@ namespace DbUp.Snowflake
             {
                 executeCallback();
             }
-            catch (OdbcException ex)
+            catch (SnowflakeDbException ex)
             {
-                Log().WriteInformation("Snowflake exception has occured in script: '{0}'", script.Name);
+                Log().WriteInformation("Snowflake exception has occurred in script: '{0}'", script.Name);
                 Log().WriteError(ex.ToString());
                 throw;
             }

--- a/SnowflakeTableJournal.cs
+++ b/SnowflakeTableJournal.cs
@@ -48,8 +48,8 @@ namespace DbUp.Snowflake
         /// <summary>Verify, using database-specific queries, if the table exists in the database.</summary>
         /// <returns>1 if table exists, 0 otherwise</returns>
         protected override string DoesTableExistSql() => string.IsNullOrEmpty(SchemaTableSchema)
-                ? $"select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName.ToUpper()}'"
-                : $"select 1 from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName.ToUpper()}' and TABLE_SCHEMA = '{SchemaTableSchema.ToUpper()}'";
+                ? $"select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName.ToUpper()}'"
+                : $"select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '{UnquotedSchemaTableName.ToUpper()}' and TABLE_SCHEMA = '{SchemaTableSchema.ToUpper()}'";
 
         protected override string CreateSchemaTableSql(string quotedPrimaryKeyName)
         {
@@ -57,7 +57,7 @@ namespace DbUp.Snowflake
             (
                 schemaversionsid int identity,
                 scriptname varchar(255),
-                applied timestamp           
+                applied timestamp
             )";
         }
     }


### PR DESCRIPTION
This fixes an issue faced when trying to query a table that doesn't exist. Instead of returning a DbNull object that isn't handled by the DbUp engine, we would now return a number (i.e. 0).

This PR also changes the project's target framework, db connection strategy, and adds support for cases where the schema may be included in a connection string.
